### PR TITLE
feat: add summary note module

### DIFF
--- a/Modules/ModuleDependencyInjection.cs
+++ b/Modules/ModuleDependencyInjection.cs
@@ -3,6 +3,7 @@ using ExecutiveDashboard.Modules.ImproveDegrade;
 using ExecutiveDashboard.Modules.MostLessWin;
 using ExecutiveDashboard.Modules.OLOPerformance;
 using ExecutiveDashboard.Modules.Summary;
+using ExecutiveDashboard.Modules.SummaryNote;
 using ExecutiveDashboard.Modules.WinLoseMetric;
 
 namespace ExecutiveDashboard.Modules
@@ -16,6 +17,7 @@ namespace ExecutiveDashboard.Modules
             services.AddOLOPerformanceModule();
             services.AddWinLoseMetricModule();
             services.AddSummaryModule();
+            services.AddSummaryNoteModule();
             services.AddImproveDegradeModule();
 
             return services;

--- a/Modules/SummaryNote/Data/Entities/SummaryNoteEntity.cs
+++ b/Modules/SummaryNote/Data/Entities/SummaryNoteEntity.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ExecutiveDashboard.Modules.SummaryNote.Data.Entities
+{
+    [Keyless]
+    public class SummaryNoteEntity
+    {
+        public int? yearweek { get; set; }
+        public int id { get; set; }
+        public string? summary { get; set; }
+    }
+}

--- a/Modules/SummaryNote/Data/SummaryNoteDbContext.cs
+++ b/Modules/SummaryNote/Data/SummaryNoteDbContext.cs
@@ -1,0 +1,10 @@
+using ExecutiveDashboard.Modules.SummaryNote.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace ExecutiveDashboard.Common
+{
+    public partial class ExecutiveDbContext : DbContext
+    {
+        public DbSet<SummaryNoteEntity> SummaryNotes { get; set; }
+    }
+}

--- a/Modules/SummaryNote/Dtos/Requests/SummaryNoteRequests.cs
+++ b/Modules/SummaryNote/Dtos/Requests/SummaryNoteRequests.cs
@@ -1,0 +1,19 @@
+namespace ExecutiveDashboard.Modules.SummaryNote.Dtos.Requests
+{
+    public class SummaryNoteQueryRequest
+    {
+        public int? Yearweek { get; init; }
+    }
+
+    public class CreateSummaryNoteRequest
+    {
+        public int? Yearweek { get; init; }
+        public string? Detail { get; init; }
+    }
+
+    public class UpdateSummaryNoteRequest
+    {
+        public int? Yearweek { get; init; }
+        public string? Detail { get; init; }
+    }
+}

--- a/Modules/SummaryNote/Dtos/Responses/SummaryNoteResponses.cs
+++ b/Modules/SummaryNote/Dtos/Responses/SummaryNoteResponses.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace ExecutiveDashboard.Modules.SummaryNote.Dtos.Responses
+{
+    public class SummaryNoteItemResponse
+    {
+        public int Id { get; init; }
+        public string? Detail { get; init; }
+        public string? Region { get; init; }
+    }
+
+    public class SummaryNoteListResponse
+    {
+        public int Total { get; init; }
+        public IReadOnlyCollection<SummaryNoteItemResponse> SummarData { get; init; } =
+            new List<SummaryNoteItemResponse>();
+    }
+}

--- a/Modules/SummaryNote/Repositories/ISummaryNoteRepository.cs
+++ b/Modules/SummaryNote/Repositories/ISummaryNoteRepository.cs
@@ -1,0 +1,11 @@
+using ExecutiveDashboard.Modules.SummaryNote.Data.Entities;
+
+namespace ExecutiveDashboard.Modules.SummaryNote.Repositories
+{
+    public interface ISummaryNoteRepository
+    {
+        Task<List<SummaryNoteEntity>> GetSummaryNotes(int? yearweek);
+        Task CreateSummaryNote(int? yearweek, string? detail);
+        Task UpdateSummaryNote(int id, int? yearweek, string? detail);
+    }
+}

--- a/Modules/SummaryNote/Repositories/SummaryNoteRepository.cs
+++ b/Modules/SummaryNote/Repositories/SummaryNoteRepository.cs
@@ -1,0 +1,59 @@
+using System;
+using ExecutiveDashboard.Common;
+using ExecutiveDashboard.Modules.SummaryNote.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace ExecutiveDashboard.Modules.SummaryNote.Repositories
+{
+    public class SummaryNoteRepository : ISummaryNoteRepository
+    {
+        private readonly ExecutiveDbContext _context;
+
+        public SummaryNoteRepository(ExecutiveDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<SummaryNoteEntity>> GetSummaryNotes(int? yearweek)
+        {
+            const string sql = "select * from semb.get_executive_dashboard_summary_card(@yearweek);";
+
+            var parameters = new[]
+            {
+                new NpgsqlParameter("yearweek", yearweek ?? (object)DBNull.Value),
+            };
+
+            return await _context.SummaryNotes.FromSqlRaw(sql, parameters).ToListAsync();
+        }
+
+        public Task CreateSummaryNote(int? yearweek, string? detail)
+        {
+            const string sql =
+                "call semb.insert_executive_dashboard_summary_card(@yearweek, @detail);";
+
+            var parameters = new[]
+            {
+                new NpgsqlParameter("yearweek", yearweek ?? (object)DBNull.Value),
+                new NpgsqlParameter("detail", detail ?? (object)DBNull.Value),
+            };
+
+            return _context.Database.ExecuteSqlRawAsync(sql, parameters);
+        }
+
+        public Task UpdateSummaryNote(int id, int? yearweek, string? detail)
+        {
+            const string sql =
+                "call semb.update_to_executive_dashboard_summary_card(@yearweek, @id, @detail);";
+
+            var parameters = new[]
+            {
+                new NpgsqlParameter("yearweek", yearweek ?? (object)DBNull.Value),
+                new NpgsqlParameter("id", id),
+                new NpgsqlParameter("detail", detail ?? (object)DBNull.Value),
+            };
+
+            return _context.Database.ExecuteSqlRawAsync(sql, parameters);
+        }
+    }
+}

--- a/Modules/SummaryNote/Services/ISummaryNoteService.cs
+++ b/Modules/SummaryNote/Services/ISummaryNoteService.cs
@@ -1,0 +1,12 @@
+using ExecutiveDashboard.Modules.SummaryNote.Dtos.Requests;
+using ExecutiveDashboard.Modules.SummaryNote.Dtos.Responses;
+
+namespace ExecutiveDashboard.Modules.SummaryNote.Services
+{
+    public interface ISummaryNoteService
+    {
+        Task<SummaryNoteListResponse> GetSummaryNotes(SummaryNoteQueryRequest request);
+        Task CreateSummaryNote(CreateSummaryNoteRequest request);
+        Task UpdateSummaryNote(int id, UpdateSummaryNoteRequest request);
+    }
+}

--- a/Modules/SummaryNote/Services/SummaryNoteService.cs
+++ b/Modules/SummaryNote/Services/SummaryNoteService.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using ExecutiveDashboard.Modules.SummaryNote.Dtos.Requests;
+using ExecutiveDashboard.Modules.SummaryNote.Dtos.Responses;
+using ExecutiveDashboard.Modules.SummaryNote.Repositories;
+
+namespace ExecutiveDashboard.Modules.SummaryNote.Services
+{
+    public class SummaryNoteService : ISummaryNoteService
+    {
+        private readonly ISummaryNoteRepository _repository;
+
+        public SummaryNoteService(ISummaryNoteRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<SummaryNoteListResponse> GetSummaryNotes(SummaryNoteQueryRequest request)
+        {
+            var rows = await _repository.GetSummaryNotes(request.Yearweek);
+
+            var items = rows
+                .Select(row => new SummaryNoteItemResponse
+                {
+                    Id = row.id,
+                    Detail = row.summary?.Trim(),
+                    Region = string.Empty,
+                })
+                .ToList();
+
+            return new SummaryNoteListResponse
+            {
+                Total = items.Count,
+                SummarData = items,
+            };
+        }
+
+        public Task CreateSummaryNote(CreateSummaryNoteRequest request)
+        {
+            return _repository.CreateSummaryNote(request.Yearweek, request.Detail);
+        }
+
+        public Task UpdateSummaryNote(int id, UpdateSummaryNoteRequest request)
+        {
+            return _repository.UpdateSummaryNote(id, request.Yearweek, request.Detail);
+        }
+    }
+}

--- a/Modules/SummaryNote/SummaryNoteController.cs
+++ b/Modules/SummaryNote/SummaryNoteController.cs
@@ -1,0 +1,54 @@
+using ExecutiveDashboard.Common;
+using ExecutiveDashboard.Modules.SummaryNote.Dtos.Requests;
+using ExecutiveDashboard.Modules.SummaryNote.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ExecutiveDashboard.Modules.SummaryNote
+{
+    [ApiController]
+    [Route("v1/summary-notes")]
+    public class SummaryNoteController : ControllerBase
+    {
+        private readonly ISummaryNoteService _service;
+
+        public SummaryNoteController(ISummaryNoteService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<BaseResponse>> GetSummaryNotes(
+            [FromQuery] SummaryNoteQueryRequest request
+        )
+        {
+            var result = await _service.GetSummaryNotes(request);
+
+            var response = BaseResponse.ToResponse(200, true, result, null);
+            return Ok(response);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<BaseResponse>> CreateSummaryNote(
+            [FromBody] CreateSummaryNoteRequest request
+        )
+        {
+            await _service.CreateSummaryNote(request);
+
+            var response = BaseResponse.ToResponse(201, true, null, null);
+            return StatusCode(StatusCodes.Status201Created, response);
+        }
+
+        [HttpPut("{id:int}")]
+        public async Task<ActionResult<BaseResponse>> UpdateSummaryNote(
+            int id,
+            [FromBody] UpdateSummaryNoteRequest request
+        )
+        {
+            await _service.UpdateSummaryNote(id, request);
+
+            var response = BaseResponse.ToResponse(200, true, null, null);
+            return Ok(response);
+        }
+    }
+}

--- a/Modules/SummaryNote/SummaryNoteDependencyInjection.cs
+++ b/Modules/SummaryNote/SummaryNoteDependencyInjection.cs
@@ -1,0 +1,15 @@
+using ExecutiveDashboard.Modules.SummaryNote.Repositories;
+using ExecutiveDashboard.Modules.SummaryNote.Services;
+
+namespace ExecutiveDashboard.Modules.ExecutiveDashboard
+{
+    public static class SummaryNoteDependencyInjection
+    {
+        public static IServiceCollection AddSummaryNoteModule(this IServiceCollection services)
+        {
+            services.AddScoped<ISummaryNoteService, SummaryNoteService>();
+            services.AddScoped<ISummaryNoteRepository, SummaryNoteRepository>();
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SummaryNote module with controller, service, repository, and DTO layers to expose list, create, and update endpoints
- register the module and extend the shared DbContext for summary note access

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c99131e62c8332b637decdb234a302