### PR TITLE
feat: add excel export for summary notes

### DIFF
--- a/Modules/SummaryNote/Services/ISummaryNoteService.cs
+++ b/Modules/SummaryNote/Services/ISummaryNoteService.cs
@@ -8,5 +8,6 @@ namespace ExecutiveDashboard.Modules.SummaryNote.Services
         Task<SummaryNoteListResponse> GetSummaryNotes(SummaryNoteQueryRequest request);
         Task CreateSummaryNote(CreateSummaryNoteRequest request);
         Task UpdateSummaryNote(int id, UpdateSummaryNoteRequest request);
+        Task<byte[]> GenerateSummaryNotesExcelFile(SummaryNoteQueryRequest request);
     }
 }

--- a/Modules/SummaryNote/Services/SummaryNoteService.cs
+++ b/Modules/SummaryNote/Services/SummaryNoteService.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using ClosedXML.Excel;
 using ExecutiveDashboard.Modules.SummaryNote.Dtos.Requests;
 using ExecutiveDashboard.Modules.SummaryNote.Dtos.Responses;
 using ExecutiveDashboard.Modules.SummaryNote.Repositories;
@@ -34,6 +35,57 @@ namespace ExecutiveDashboard.Modules.SummaryNote.Services
             };
         }
 
+        public async Task<XLWorkbook> GenerateSummaryNotesWorkbook(SummaryNoteQueryRequest request)
+        {
+            var summaryNotes = await GetSummaryNotes(request);
+
+            var workbook = new XLWorkbook();
+            var worksheet = workbook.Worksheets.Add("SummaryNotes");
+
+            worksheet.Range("A1:B1").Merge().Value = "Metadata";
+            worksheet.Range("A1:B1").Style.Font.Bold = true;
+            worksheet.Range("A1:B1").Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+
+            var currentRow = 2;
+
+            worksheet.Cell(currentRow, 1).Value = "Yearweek";
+            worksheet.Cell(currentRow, 2).Value = request.Yearweek?.ToString() ?? "-";
+            currentRow++;
+
+            worksheet.Cell(currentRow, 1).Value = "Total Notes";
+            worksheet.Cell(currentRow, 2).Value = summaryNotes.Total;
+            currentRow += 2;
+
+            worksheet.Cell(currentRow, 1).Value = "ID";
+            worksheet.Cell(currentRow, 2).Value = "Detail";
+            worksheet.Cell(currentRow, 3).Value = "Region";
+
+            var headerRange = worksheet.Range(currentRow, 1, currentRow, 3);
+            headerRange.Style.Font.Bold = true;
+            headerRange.Style.Fill.BackgroundColor = XLColor.LightGray;
+            headerRange.Style.Border.OutsideBorder = XLBorderStyleValues.Thin;
+            headerRange.Style.Border.InsideBorder = XLBorderStyleValues.Thin;
+
+            currentRow++;
+
+            foreach (var note in summaryNotes.SummarData)
+            {
+                worksheet.Cell(currentRow, 1).Value = note.Id;
+                worksheet.Cell(currentRow, 2).Value = note.Detail;
+                worksheet.Cell(currentRow, 3).Value = note.Region;
+
+                var dataRange = worksheet.Range(currentRow, 1, currentRow, 3);
+                dataRange.Style.Border.OutsideBorder = XLBorderStyleValues.Thin;
+                dataRange.Style.Border.InsideBorder = XLBorderStyleValues.Thin;
+
+                currentRow++;
+            }
+
+            worksheet.Columns().AdjustToContents();
+
+            return workbook;
+        }
+
         public Task CreateSummaryNote(CreateSummaryNoteRequest request)
         {
             return _repository.CreateSummaryNote(request.Yearweek, request.Detail);
@@ -42,6 +94,15 @@ namespace ExecutiveDashboard.Modules.SummaryNote.Services
         public Task UpdateSummaryNote(int id, UpdateSummaryNoteRequest request)
         {
             return _repository.UpdateSummaryNote(id, request.Yearweek, request.Detail);
+        }
+
+        public async Task<byte[]> GenerateSummaryNotesExcelFile(SummaryNoteQueryRequest request)
+        {
+            using var workbook = await GenerateSummaryNotesWorkbook(request);
+            using var stream = new MemoryStream();
+
+            workbook.SaveAs(stream);
+            return stream.ToArray();
         }
     }
 }

--- a/Modules/SummaryNote/SummaryNoteController.cs
+++ b/Modules/SummaryNote/SummaryNoteController.cs
@@ -28,6 +28,22 @@ namespace ExecutiveDashboard.Modules.SummaryNote
             return Ok(response);
         }
 
+        [HttpGet("excel")]
+        public async Task<IActionResult> DownloadSummaryNotes(
+            [FromQuery] SummaryNoteQueryRequest request
+        )
+        {
+            var excelBytes = await _service.GenerateSummaryNotesExcelFile(request);
+
+            var fileName = $"SummaryNotes_{request.Yearweek?.ToString() ?? "all"}.xlsx";
+
+            return File(
+                excelBytes,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                fileName
+            );
+        }
+
         [HttpPost]
         public async Task<ActionResult<BaseResponse>> CreateSummaryNote(
             [FromBody] CreateSummaryNoteRequest request


### PR DESCRIPTION
## Summary
- add an Excel download endpoint for the summary notes module
- build workbook generation with metadata and a notes table for the export
- expose service methods to produce the Excel payload

## Testing
- dotnet build *(fails: dotnet command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e51caf9483329e8fadf16eca1970