### PR TITLE
feat: add consolidated excel export module

### DIFF
--- a/Modules/ExcelExport/Dtos/Requests/ExcelExportRequest.cs
+++ b/Modules/ExcelExport/Dtos/Requests/ExcelExportRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ExecutiveDashboard.Modules.ExcelExport.Dtos.Requests
+{
+    public record ExcelExportRequest
+    {
+        [Required(ErrorMessage = "yearweek_required")]
+        public int? Yearweek { get; init; }
+
+        [Required(ErrorMessage = "level_required")]
+        [RegularExpression("nation|region|kabupaten", ErrorMessage = "level_allowed")]
+        public string? Level { get; init; }
+
+        [Required(ErrorMessage = "location_required")]
+        public string? Location { get; init; }
+    }
+}

--- a/Modules/ExcelExport/ExcelExportController.cs
+++ b/Modules/ExcelExport/ExcelExportController.cs
@@ -1,0 +1,32 @@
+using ExecutiveDashboard.Modules.ExcelExport.Dtos.Requests;
+using ExecutiveDashboard.Modules.ExcelExport.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ExecutiveDashboard.Modules.ExcelExport
+{
+    [ApiController]
+    [Route("v1")]
+    public class ExcelExportController : ControllerBase
+    {
+        private readonly IExcelExportService _service;
+
+        public ExcelExportController(IExcelExportService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet("excel-export")]
+        public async Task<IActionResult> DownloadExcel([FromQuery] ExcelExportRequest request)
+        {
+            var excelBytes = await _service.GenerateExcelExportFile(request);
+
+            var fileName = $"dashboard-export-{request.Yearweek}-{request.Location}.xlsx";
+
+            return File(
+                excelBytes,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                fileName
+            );
+        }
+    }
+}

--- a/Modules/ExcelExport/ExcelExportDependencyInjection.cs
+++ b/Modules/ExcelExport/ExcelExportDependencyInjection.cs
@@ -1,0 +1,13 @@
+using ExecutiveDashboard.Modules.ExcelExport.Services;
+
+namespace ExecutiveDashboard.Modules.ExcelExport
+{
+    public static class ExcelExportDependencyInjection
+    {
+        public static IServiceCollection AddExcelExportModule(this IServiceCollection services)
+        {
+            services.AddScoped<IExcelExportService, ExcelExportService>();
+            return services;
+        }
+    }
+}

--- a/Modules/ExcelExport/Services/ExcelExportService.cs
+++ b/Modules/ExcelExport/Services/ExcelExportService.cs
@@ -1,0 +1,182 @@
+using System.Globalization;
+using System.IO;
+using ClosedXML.Excel;
+using ExecutiveDashboard.Common.Exceptions;
+using ExecutiveDashboard.Modules.ExcelExport.Dtos.Requests;
+using ExecutiveDashboard.Modules.ImproveDegrade.Dtos.Requests;
+using ExecutiveDashboard.Modules.ImproveDegrade.Services;
+using ExecutiveDashboard.Modules.MostLessWin.Dtos.Requests;
+using ExecutiveDashboard.Modules.MostLessWin.Services;
+using ExecutiveDashboard.Modules.OLOPerformance.Dtos.Requests;
+using ExecutiveDashboard.Modules.OLOPerformance.Services;
+using ExecutiveDashboard.Modules.Summary.Dtos.Requests;
+using ExecutiveDashboard.Modules.Summary.Services;
+using ExecutiveDashboard.Modules.SummaryNote.Dtos.Requests;
+using ExecutiveDashboard.Modules.SummaryNote.Services;
+using ExecutiveDashboard.Modules.WinLoseMetric.Dtos.Requests;
+using ExecutiveDashboard.Modules.WinLoseMetric.Services;
+
+namespace ExecutiveDashboard.Modules.ExcelExport.Services
+{
+    public class ExcelExportService : IExcelExportService
+    {
+        private static readonly string[] Sources = new[] { "open_signal", "ookla" };
+        private static readonly string[] Statuses = new[] { "lose", "win" };
+
+        private readonly IWinLoseMetricService _winLoseMetricService;
+        private readonly IMostLessWinService _mostLessWinService;
+        private readonly IImproveDegradeService _improveDegradeService;
+        private readonly ISummaryService _summaryService;
+        private readonly ISummaryNoteService _summaryNoteService;
+        private readonly IOLOPerformanceService _oloPerformanceService;
+
+        public ExcelExportService(
+            IWinLoseMetricService winLoseMetricService,
+            IMostLessWinService mostLessWinService,
+            IImproveDegradeService improveDegradeService,
+            ISummaryService summaryService,
+            ISummaryNoteService summaryNoteService,
+            IOLOPerformanceService oloPerformanceService
+        )
+        {
+            _winLoseMetricService = winLoseMetricService;
+            _mostLessWinService = mostLessWinService;
+            _improveDegradeService = improveDegradeService;
+            _summaryService = summaryService;
+            _summaryNoteService = summaryNoteService;
+            _oloPerformanceService = oloPerformanceService;
+        }
+
+        public async Task<XLWorkbook> GenerateExcelExportWorkbook(ExcelExportRequest request)
+        {
+            var workbook = new XLWorkbook();
+            var hasWorksheet = false;
+
+            async Task TryAddWorksheet(Func<Task<IXLWorksheet>> createWorksheet)
+            {
+                try
+                {
+                    await createWorksheet();
+                    hasWorksheet = true;
+                }
+                catch (NotFoundException)
+                {
+                    // Skip sheets without data
+                }
+            }
+
+            var summaryRequest = new SummaryRequest
+            {
+                Yearweek = request.Yearweek,
+                Level = request.Level,
+                Location = request.Location,
+            };
+
+            await TryAddWorksheet(() =>
+                _summaryService.CreateSummaryWorksheet(workbook, summaryRequest, "Summary")
+            );
+
+            await TryAddWorksheet(() => _summaryNoteService.CreateSummaryNotesWorksheet(
+                workbook,
+                new SummaryNoteQueryRequest { Yearweek = request.Yearweek },
+                "Summary Notes"
+            ));
+
+            var oloRequest = new OLOPerformanceRequest
+            {
+                Yearweek = request.Yearweek,
+                Level = request.Level,
+                Location = request.Location,
+            };
+
+            await TryAddWorksheet(() =>
+                _oloPerformanceService.CreateOloPerformanceWorksheet(
+                    workbook,
+                    oloRequest,
+                    "OLO Performance"
+                )
+            );
+
+            await TryAddWorksheet(() =>
+                _oloPerformanceService.CreateOloPerformanceSummaryWorksheet(
+                    workbook,
+                    oloRequest,
+                    "OLO Performance Summary"
+                )
+            );
+
+            foreach (var source in Sources)
+            {
+                var formattedSource = ToTitleCase(source);
+
+                await TryAddWorksheet(() =>
+                    _mostLessWinService.CreateWinLoseMetricsWorksheet(
+                        workbook,
+                        new MostLessWinRequest
+                        {
+                            Yearweek = request.Yearweek,
+                            Level = request.Level,
+                            Location = request.Location,
+                            Source = source,
+                        },
+                        $"Most Less Win {formattedSource}"
+                    )
+                );
+
+                await TryAddWorksheet(() =>
+                    _improveDegradeService.CreateWinLoseWorksheet(
+                        workbook,
+                        new ImproveDegradeRequest
+                        {
+                            Yearweek = request.Yearweek,
+                            Source = source,
+                        },
+                        $"Improve Degrade {formattedSource}"
+                    )
+                );
+
+                foreach (var status in Statuses)
+                {
+                    var worksheetName =
+                        $"Win Lose {formattedSource} {ToTitleCase(status)}";
+
+                    await TryAddWorksheet(() =>
+                        _winLoseMetricService.CreateWinLoseMetricsWorksheet(
+                            workbook,
+                            new WinLoseMetricRequest
+                            {
+                                Yearweek = request.Yearweek,
+                                Level = request.Level,
+                                Location = request.Location,
+                                Source = source,
+                                Status = status,
+                            },
+                            worksheetName
+                        )
+                    );
+                }
+            }
+
+            if (!hasWorksheet)
+            {
+                throw new NotFoundException("not_found");
+            }
+
+            return workbook;
+        }
+
+        public async Task<byte[]> GenerateExcelExportFile(ExcelExportRequest request)
+        {
+            using var workbook = await GenerateExcelExportWorkbook(request);
+            using var stream = new MemoryStream();
+            workbook.SaveAs(stream);
+            return stream.ToArray();
+        }
+
+        private static string ToTitleCase(string value)
+        {
+            var normalized = value.Replace("_", " ");
+            return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(normalized);
+        }
+    }
+}

--- a/Modules/ExcelExport/Services/IExcelExportService.cs
+++ b/Modules/ExcelExport/Services/IExcelExportService.cs
@@ -1,0 +1,11 @@
+using ClosedXML.Excel;
+using ExecutiveDashboard.Modules.ExcelExport.Dtos.Requests;
+
+namespace ExecutiveDashboard.Modules.ExcelExport.Services
+{
+    public interface IExcelExportService
+    {
+        Task<XLWorkbook> GenerateExcelExportWorkbook(ExcelExportRequest request);
+        Task<byte[]> GenerateExcelExportFile(ExcelExportRequest request);
+    }
+}

--- a/Modules/ImproveDegrade/Services/IImproveDegradeService.cs
+++ b/Modules/ImproveDegrade/Services/IImproveDegradeService.cs
@@ -7,6 +7,11 @@ namespace ExecutiveDashboard.Modules.ImproveDegrade.Services
     public interface IImproveDegradeService
     {
         Task<List<NewImproveDegradeResponse>> GetImproveDegrade(ImproveDegradeRequest request);
+        Task<IXLWorksheet> CreateWinLoseWorksheet(
+            XLWorkbook workbook,
+            ImproveDegradeRequest request,
+            string? worksheetName = null
+        );
         Task<XLWorkbook> GenerateWinLoseWorkbook(ImproveDegradeRequest request);
         Task<byte[]> GenerateWinLoseExcelFile(ImproveDegradeRequest request);
     }

--- a/Modules/ImproveDegrade/Services/ImproveDegradeService.cs
+++ b/Modules/ImproveDegrade/Services/ImproveDegradeService.cs
@@ -182,13 +182,20 @@ namespace ExecutiveDashboard.Modules.ImproveDegrade.Services
             return s.Trim().TrimEnd('.', ',').Trim();
         }
 
-        public async Task<XLWorkbook> GenerateWinLoseWorkbook(ImproveDegradeRequest request)
+        public async Task<IXLWorksheet> CreateWinLoseWorksheet(
+            XLWorkbook workbook,
+            ImproveDegradeRequest request,
+            string? worksheetName = null
+        )
         {
             // Get data from existing service method
             var data = await GetImproveDegrade(request);
 
-            var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("ImproveDegrade Report");
+            var worksheetNameToUse = string.IsNullOrWhiteSpace(worksheetName)
+                ? "ImproveDegrade Report"
+                : worksheetName;
+
+            var worksheet = workbook.Worksheets.Add(worksheetNameToUse);
 
             int currentRow = 1;
 
@@ -210,6 +217,13 @@ namespace ExecutiveDashboard.Modules.ImproveDegrade.Services
             // Auto-fit columns
             worksheet.Columns().AdjustToContents();
 
+            return worksheet;
+        }
+
+        public async Task<XLWorkbook> GenerateWinLoseWorkbook(ImproveDegradeRequest request)
+        {
+            var workbook = new XLWorkbook();
+            await CreateWinLoseWorksheet(workbook, request);
             return workbook;
         }
 

--- a/Modules/ModuleDependencyInjection.cs
+++ b/Modules/ModuleDependencyInjection.cs
@@ -1,3 +1,4 @@
+using ExecutiveDashboard.Modules.ExcelExport;
 using ExecutiveDashboard.Modules.ExecutiveDashboard;
 using ExecutiveDashboard.Modules.ImproveDegrade;
 using ExecutiveDashboard.Modules.MostLessWin;
@@ -19,6 +20,7 @@ namespace ExecutiveDashboard.Modules
             services.AddSummaryModule();
             services.AddSummaryNoteModule();
             services.AddImproveDegradeModule();
+            services.AddExcelExportModule();
 
             return services;
         }

--- a/Modules/MostLessWin/Services/IMostLessWinService.cs
+++ b/Modules/MostLessWin/Services/IMostLessWinService.cs
@@ -7,6 +7,11 @@ namespace ExecutiveDashboard.Modules.MostLessWin.Services
     public interface IMostLessWinService
     {
         Task<MostLessWinResponse> GetMostLessWin(MostLessWinRequest request);
+        Task<IXLWorksheet> CreateWinLoseMetricsWorksheet(
+            XLWorkbook workbook,
+            MostLessWinRequest request,
+            string? worksheetName = null
+        );
         Task<XLWorkbook> GenerateWinLoseMetricsWorkbook(MostLessWinRequest request);
         Task<byte[]> GenerateWinLoseMetricsExcelFile(MostLessWinRequest request);
     }

--- a/Modules/MostLessWin/Services/MostLessWinService.cs
+++ b/Modules/MostLessWin/Services/MostLessWinService.cs
@@ -58,7 +58,11 @@ namespace ExecutiveDashboard.Modules.MostLessWin.Services
             return result;
         }
 
-        public async Task<XLWorkbook> GenerateWinLoseMetricsWorkbook(MostLessWinRequest request)
+        public async Task<IXLWorksheet> CreateWinLoseMetricsWorksheet(
+            XLWorkbook workbook,
+            MostLessWinRequest request,
+            string? worksheetName = null
+        )
         {
             // Get data from repository
             var data = await _repo.GetMostWinForLatestWeek(
@@ -68,9 +72,11 @@ namespace ExecutiveDashboard.Modules.MostLessWin.Services
                 request.Source!
             );
 
-            // Create new workbook
-            var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("WinLoseMetrics");
+            var worksheetNameToUse = string.IsNullOrWhiteSpace(worksheetName)
+                ? "WinLoseMetrics"
+                : worksheetName;
+
+            var worksheet = workbook.Worksheets.Add(worksheetNameToUse);
 
             // Add metadata section
             worksheet.Cell(1, 1).Value = "Win/Lose Metrics Report";
@@ -138,6 +144,13 @@ namespace ExecutiveDashboard.Modules.MostLessWin.Services
             // Auto-fit columns
             worksheet.Columns().AdjustToContents();
 
+            return worksheet;
+        }
+
+        public async Task<XLWorkbook> GenerateWinLoseMetricsWorkbook(MostLessWinRequest request)
+        {
+            var workbook = new XLWorkbook();
+            await CreateWinLoseMetricsWorksheet(workbook, request);
             return workbook;
         }
 

--- a/Modules/OLOPerformance/Services/IOLOPerformanceService.cs
+++ b/Modules/OLOPerformance/Services/IOLOPerformanceService.cs
@@ -8,9 +8,19 @@ namespace ExecutiveDashboard.Modules.OLOPerformance.Services
     {
         Task<OLOPerformanceResponse> GetOloPerformance(OLOPerformanceRequest request);
         Task<OLOPerformanceSummaryResponse> GetOloPerformanceSummary(OLOPerformanceRequest request);
+        Task<IXLWorksheet> CreateOloPerformanceWorksheet(
+            XLWorkbook workbook,
+            OLOPerformanceRequest request,
+            string? worksheetName = null
+        );
         Task<XLWorkbook> GenerateOloPerformanceWorkbook(OLOPerformanceRequest request);
         Task<byte[]> GenerateOloPerformanceExcelFile(OLOPerformanceRequest request);
 
+        Task<IXLWorksheet> CreateOloPerformanceSummaryWorksheet(
+            XLWorkbook workbook,
+            OLOPerformanceRequest request,
+            string? worksheetName = null
+        );
         Task<XLWorkbook> GenerateOloPerformanceSummaryWorkbook(OLOPerformanceRequest request);
         Task<byte[]> GenerateOloPerformanceSummaryExcelFile(OLOPerformanceRequest request);
     }

--- a/Modules/OLOPerformance/Services/OLOPerformanceService.cs
+++ b/Modules/OLOPerformance/Services/OLOPerformanceService.cs
@@ -164,7 +164,11 @@ namespace ExecutiveDashboard.Modules.OLOPerformance.Services
             return response;
         }
 
-        public async Task<XLWorkbook> GenerateOloPerformanceWorkbook(OLOPerformanceRequest request)
+        public async Task<IXLWorksheet> CreateOloPerformanceWorksheet(
+            XLWorkbook workbook,
+            OLOPerformanceRequest request,
+            string? worksheetName = null
+        )
         {
             var rows = await _repo.GetOloPerformance(
                 request.Yearweek,
@@ -177,8 +181,11 @@ namespace ExecutiveDashboard.Modules.OLOPerformance.Services
                 throw new NotFoundException("not_found");
             }
 
-            var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("OLO Performance");
+            var worksheetNameToUse = string.IsNullOrWhiteSpace(worksheetName)
+                ? "OLO Performance"
+                : worksheetName;
+
+            var worksheet = workbook.Worksheets.Add(worksheetNameToUse);
 
             // Add Metadata Section
             var currentRow = 1;
@@ -231,6 +238,13 @@ namespace ExecutiveDashboard.Modules.OLOPerformance.Services
             // Auto-fit columns
             worksheet.Columns().AdjustToContents();
 
+            return worksheet;
+        }
+
+        public async Task<XLWorkbook> GenerateOloPerformanceWorkbook(OLOPerformanceRequest request)
+        {
+            var workbook = new XLWorkbook();
+            await CreateOloPerformanceWorksheet(workbook, request);
             return workbook;
         }
 
@@ -242,14 +256,19 @@ namespace ExecutiveDashboard.Modules.OLOPerformance.Services
             return stream.ToArray();
         }
 
-        public async Task<XLWorkbook> GenerateOloPerformanceSummaryWorkbook(
-            OLOPerformanceRequest request
+        public async Task<IXLWorksheet> CreateOloPerformanceSummaryWorksheet(
+            XLWorkbook workbook,
+            OLOPerformanceRequest request,
+            string? worksheetName = null
         )
         {
             var summary = await GetOloPerformanceSummary(request);
 
-            var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("OLO Performance Summary");
+            var worksheetNameToUse = string.IsNullOrWhiteSpace(worksheetName)
+                ? "OLO Performance Summary"
+                : worksheetName;
+
+            var worksheet = workbook.Worksheets.Add(worksheetNameToUse);
 
             int currentRow = 1;
 
@@ -336,6 +355,15 @@ namespace ExecutiveDashboard.Modules.OLOPerformance.Services
 
             worksheet.Columns().AdjustToContents();
 
+            return worksheet;
+        }
+
+        public async Task<XLWorkbook> GenerateOloPerformanceSummaryWorkbook(
+            OLOPerformanceRequest request
+        )
+        {
+            var workbook = new XLWorkbook();
+            await CreateOloPerformanceSummaryWorksheet(workbook, request);
             return workbook;
         }
 

--- a/Modules/Summary/Services/ISummaryService.cs
+++ b/Modules/Summary/Services/ISummaryService.cs
@@ -1,3 +1,4 @@
+using ClosedXML.Excel;
 using ExecutiveDashboard.Modules.Summary.Dtos.Requests;
 using ExecutiveDashboard.Modules.Summary.Dtos.Responses;
 
@@ -6,6 +7,12 @@ namespace ExecutiveDashboard.Modules.Summary.Services
     public interface ISummaryService
     {
         Task<SummaryResponse> GetSummary(SummaryRequest request);
+        Task<IXLWorksheet> CreateSummaryWorksheet(
+            XLWorkbook workbook,
+            SummaryRequest request,
+            string? worksheetName = null
+        );
+        Task<XLWorkbook> GenerateSummaryWorkbook(SummaryRequest request);
         Task<byte[]> GenerateSummaryExcelFile(SummaryRequest request);
     }
 }

--- a/Modules/Summary/Services/SummaryService.cs
+++ b/Modules/Summary/Services/SummaryService.cs
@@ -174,13 +174,20 @@ namespace ExecutiveDashboard.Modules.Summary.Services
             return response;
         }
 
-        public async Task<XLWorkbook> GenerateSummaryWorkbook(SummaryRequest request)
+        public async Task<IXLWorksheet> CreateSummaryWorksheet(
+            XLWorkbook workbook,
+            SummaryRequest request,
+            string? worksheetName = null
+        )
         {
             // Ambil data dari service yang sudah ada
             var summary = await GetSummary(request);
 
-            var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("Summary");
+            var worksheetNameToUse = string.IsNullOrWhiteSpace(worksheetName)
+                ? "Summary"
+                : worksheetName;
+
+            var worksheet = workbook.Worksheets.Add(worksheetNameToUse);
 
             // === Metadata ===
             worksheet.Range("A1:B1").Merge().Value = "Metadata";
@@ -285,6 +292,13 @@ namespace ExecutiveDashboard.Modules.Summary.Services
 
             worksheet.Columns().AdjustToContents();
 
+            return worksheet;
+        }
+
+        public async Task<XLWorkbook> GenerateSummaryWorkbook(SummaryRequest request)
+        {
+            var workbook = new XLWorkbook();
+            await CreateSummaryWorksheet(workbook, request);
             return workbook;
         }
 

--- a/Modules/SummaryNote/Services/ISummaryNoteService.cs
+++ b/Modules/SummaryNote/Services/ISummaryNoteService.cs
@@ -1,3 +1,4 @@
+using ClosedXML.Excel;
 using ExecutiveDashboard.Modules.SummaryNote.Dtos.Requests;
 using ExecutiveDashboard.Modules.SummaryNote.Dtos.Responses;
 
@@ -8,6 +9,11 @@ namespace ExecutiveDashboard.Modules.SummaryNote.Services
         Task<SummaryNoteListResponse> GetSummaryNotes(SummaryNoteQueryRequest request);
         Task CreateSummaryNote(CreateSummaryNoteRequest request);
         Task UpdateSummaryNote(int id, UpdateSummaryNoteRequest request);
+        Task<IXLWorksheet> CreateSummaryNotesWorksheet(
+            XLWorkbook workbook,
+            SummaryNoteQueryRequest request,
+            string? worksheetName = null
+        );
         Task<byte[]> GenerateSummaryNotesExcelFile(SummaryNoteQueryRequest request);
     }
 }

--- a/Modules/SummaryNote/Services/SummaryNoteService.cs
+++ b/Modules/SummaryNote/Services/SummaryNoteService.cs
@@ -35,12 +35,19 @@ namespace ExecutiveDashboard.Modules.SummaryNote.Services
             };
         }
 
-        public async Task<XLWorkbook> GenerateSummaryNotesWorkbook(SummaryNoteQueryRequest request)
+        public async Task<IXLWorksheet> CreateSummaryNotesWorksheet(
+            XLWorkbook workbook,
+            SummaryNoteQueryRequest request,
+            string? worksheetName = null
+        )
         {
             var summaryNotes = await GetSummaryNotes(request);
 
-            var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("SummaryNotes");
+            var worksheetNameToUse = string.IsNullOrWhiteSpace(worksheetName)
+                ? "SummaryNotes"
+                : worksheetName;
+
+            var worksheet = workbook.Worksheets.Add(worksheetNameToUse);
 
             worksheet.Range("A1:B1").Merge().Value = "Metadata";
             worksheet.Range("A1:B1").Style.Font.Bold = true;
@@ -83,7 +90,7 @@ namespace ExecutiveDashboard.Modules.SummaryNote.Services
 
             worksheet.Columns().AdjustToContents();
 
-            return workbook;
+            return worksheet;
         }
 
         public Task CreateSummaryNote(CreateSummaryNoteRequest request)
@@ -94,6 +101,13 @@ namespace ExecutiveDashboard.Modules.SummaryNote.Services
         public Task UpdateSummaryNote(int id, UpdateSummaryNoteRequest request)
         {
             return _repository.UpdateSummaryNote(id, request.Yearweek, request.Detail);
+        }
+
+        public async Task<XLWorkbook> GenerateSummaryNotesWorkbook(SummaryNoteQueryRequest request)
+        {
+            var workbook = new XLWorkbook();
+            await CreateSummaryNotesWorksheet(workbook, request);
+            return workbook;
         }
 
         public async Task<byte[]> GenerateSummaryNotesExcelFile(SummaryNoteQueryRequest request)

--- a/Modules/WinLoseMetric/Services/IWinLoseMetricService.cs
+++ b/Modules/WinLoseMetric/Services/IWinLoseMetricService.cs
@@ -7,6 +7,11 @@ namespace ExecutiveDashboard.Modules.WinLoseMetric.Services
     public interface IWinLoseMetricService
     {
         Task<WinLoseMetricResponse> GetWinLoseMetrics(WinLoseMetricRequest request);
+        Task<IXLWorksheet> CreateWinLoseMetricsWorksheet(
+            XLWorkbook workbook,
+            WinLoseMetricRequest request,
+            string? worksheetName = null
+        );
         Task<XLWorkbook> GenerateWinLoseMetricsWorkbook(WinLoseMetricRequest request);
         Task<byte[]> GenerateWinLoseMetricsExcelFile(WinLoseMetricRequest request);
     }

--- a/Modules/WinLoseMetric/Services/WinLoseMetricService.cs
+++ b/Modules/WinLoseMetric/Services/WinLoseMetricService.cs
@@ -62,17 +62,23 @@ namespace ExecutiveDashboard.Modules.WinLoseMetric.Services
             return response;
         }
 
-        public async Task<XLWorkbook> GenerateWinLoseMetricsWorkbook(WinLoseMetricRequest request)
+        public async Task<IXLWorksheet> CreateWinLoseMetricsWorksheet(
+            XLWorkbook workbook,
+            WinLoseMetricRequest request,
+            string? worksheetName = null
+        )
         {
             // Get data using existing method
             var response = await GetWinLoseMetrics(request);
-            
-            // Create new workbook and worksheet
-            var workbook = new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add("WinLoseMetrics");
-            
+
+            var worksheetNameToUse = string.IsNullOrWhiteSpace(worksheetName)
+                ? "WinLoseMetrics"
+                : worksheetName;
+
+            var worksheet = workbook.Worksheets.Add(worksheetNameToUse);
+
             int currentRow = 1;
-            
+
             // Section 1: Metadata
             worksheet.Range("A1:B1").Merge().Value = "Metadata";
             worksheet.Range("A1:B1").Style.Font.Bold = true;
@@ -141,10 +147,17 @@ namespace ExecutiveDashboard.Modules.WinLoseMetric.Services
             
             // Auto-fit columns
             worksheet.Columns().AdjustToContents();
-            
+
+            return worksheet;
+        }
+
+        public async Task<XLWorkbook> GenerateWinLoseMetricsWorkbook(WinLoseMetricRequest request)
+        {
+            var workbook = new XLWorkbook();
+            await CreateWinLoseMetricsWorksheet(workbook, request);
             return workbook;
         }
-        
+
         public async Task<byte[]> GenerateWinLoseMetricsExcelFile(WinLoseMetricRequest request)
         {
             using var workbook = await GenerateWinLoseMetricsWorkbook(request);


### PR DESCRIPTION
## Summary
- add an ExcelExport module that aggregates worksheets from the existing services into a single download endpoint
- refactor the workbook generators in existing services so worksheet creation can be reused by the export module

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e97ebc488332a0637c0d9a1be9f6